### PR TITLE
Add corporate api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,22 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    bigdecimal (3.1.6)
+    crack (0.4.6)
+      bigdecimal
+      rexml
     diff-lcs (1.5.0)
+    hashdiff (1.1.0)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     mini_mime (1.1.5)
     multi_xml (0.6.0)
+    public_suffix (5.0.4)
     rake (13.1.0)
+    rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -27,6 +36,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.1)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   arm64-darwin-22
@@ -36,6 +49,7 @@ DEPENDENCIES
   monobank!
   rake (~> 13.0, >= 13.0.0)
   rspec (~> 3.8, >= 3.8.0)
+  webmock
 
 BUNDLED WITH
    2.5.5

--- a/lib/monobank.rb
+++ b/lib/monobank.rb
@@ -1,5 +1,6 @@
 require 'monobank/version'
 require 'monobank/client'
+require 'monobank/corporate'
 require 'forwardable'
 
 module Monobank

--- a/lib/monobank/auth/corporate.rb
+++ b/lib/monobank/auth/corporate.rb
@@ -1,0 +1,35 @@
+module Monobank
+  module Auth
+    class Corporate
+      def initialize(private_key:, key_id: nil, request_id: nil)
+        @private_key = init_key(private_key:)
+        @key_id = key_id
+        @request_id = request_id
+      end
+
+      def to_headers(pathname:)
+        time = Time.now.to_i
+
+        {
+          'X-Time' => time.to_s,
+          'X-Sign' => Base64.strict_encode64(sign(pathname:, time:))
+        }.tap do |headers|
+          headers['X-Key-Id'] = key_id unless key_id.nil?
+          headers['X-Request-Id'] = request_id unless request_id.nil?
+        end
+      end
+
+      private
+
+      attr_accessor :private_key, :key_id, :request_id
+
+      def init_key(private_key:)
+        OpenSSL::PKey::EC.new(private_key)
+      end
+
+      def sign(pathname:, time:)
+        private_key.sign(OpenSSL::Digest::SHA256.new, "#{time}#{request_id}#{pathname}")
+      end
+    end
+  end
+end

--- a/lib/monobank/auth/private.rb
+++ b/lib/monobank/auth/private.rb
@@ -1,0 +1,17 @@
+module Monobank
+  module Auth
+    class Private
+      def initialize(token:)
+        @token = token
+      end
+
+      def to_headers
+        { 'X-Token' => token }
+      end
+
+      private
+
+      attr_reader :token
+    end
+  end
+end

--- a/lib/monobank/auth/private.rb
+++ b/lib/monobank/auth/private.rb
@@ -5,7 +5,7 @@ module Monobank
         @token = token
       end
 
-      def to_headers
+      def to_headers(*)
         { 'X-Token' => token }
       end
 

--- a/lib/monobank/client.rb
+++ b/lib/monobank/client.rb
@@ -1,4 +1,5 @@
 require 'monobank/connection'
+require 'monobank/auth/private'
 require 'monobank/bank/currency'
 require 'monobank/personal/client_info'
 require 'monobank/personal/statement'
@@ -11,15 +12,21 @@ module Monobank
     end
 
     def client_info(token:)
-      Personal::ClientInfo.new(token: token).call
+      Personal::ClientInfo.new(auth: auth(token:)).call
     end
 
     def statement(token:, account_id:, from:, to: nil)
-      Personal::Statement.new(token: token, account_id: account_id, from: from, to: to).call
+      Personal::Statement.new(account_id:, from:, to:, auth: auth(token:)).call
     end
 
     def set_webhook(token:, url:)
-      Personal::Webhook.new(token: token, url: url).call
+      Personal::Webhook.new(url:, auth: auth(token:)).call
+    end
+
+    private
+
+    def auth(token:)
+      Auth::Private.new(token:)
     end
   end
 end

--- a/lib/monobank/corporate.rb
+++ b/lib/monobank/corporate.rb
@@ -4,7 +4,9 @@ require 'monobank/corporate/client'
 module Monobank
   module Corporate
     extend SingleForwardable
-    def_delegators :client, :registration, :registration_status, :set_webhook, :settings
+    def_delegators \
+      :client, :registration, :registration_status, :set_webhook, :settings,
+      :auth_request, :auth_check, :client_info, :statement
 
     def self.configure(private_key:, key_id: nil)
       @private_key = private_key

--- a/lib/monobank/corporate.rb
+++ b/lib/monobank/corporate.rb
@@ -1,0 +1,19 @@
+require 'forwardable'
+require 'monobank/corporate/client'
+
+module Monobank
+  module Corporate
+    extend SingleForwardable
+    def_delegators :client, :registration, :registration_status, :set_webhook, :settings
+
+    def self.configure(private_key:, key_id: nil)
+      @private_key = private_key
+      @key_id = key_id
+      @client = nil
+    end
+
+    def self.client
+      @client ||= Client.new(private_key: @private_key, key_id: @key_id)
+    end
+  end
+end

--- a/lib/monobank/corporate/client.rb
+++ b/lib/monobank/corporate/client.rb
@@ -3,6 +3,10 @@ require 'monobank/personal/registration'
 require 'monobank/personal/registration_status'
 require 'monobank/personal/corporate_webhook'
 require 'monobank/personal/settings'
+require 'monobank/personal/auth_request'
+require 'monobank/personal/auth_check'
+require 'monobank/personal/client_info'
+require 'monobank/personal/statement'
 
 module Monobank
   module Corporate
@@ -26,6 +30,22 @@ module Monobank
 
       def settings
         Personal::Settings.new(auth:).call
+      end
+
+      def auth_request(callback: nil)
+        Personal::AuthRequest.new(callback:, auth:).call
+      end
+
+      def auth_check(request_id:)
+        Personal::AuthCheck.new(auth: auth(request_id:)).call
+      end
+
+      def client_info(request_id:)
+        Personal::ClientInfo.new(auth: auth(request_id:)).call
+      end
+
+      def statement(request_id:, account_id:, from:, to: nil)
+        Personal::Statement.new(account_id:, from:, to:, auth: auth(request_id:)).call
       end
 
       private

--- a/lib/monobank/corporate/client.rb
+++ b/lib/monobank/corporate/client.rb
@@ -1,0 +1,40 @@
+require 'monobank/auth/corporate'
+require 'monobank/personal/registration'
+require 'monobank/personal/registration_status'
+require 'monobank/personal/corporate_webhook'
+require 'monobank/personal/settings'
+
+module Monobank
+  module Corporate
+    class Client
+      def initialize(private_key:, key_id:)
+        @private_key = private_key
+        @key_id = key_id
+      end
+
+      def registration(public_key:, name:, description:, contact_person:, phone:, email:, logo:)
+        Personal::Registration.new(public_key:, name:, description:, contact_person:, phone:, email:, logo:, auth:).call
+      end
+
+      def registration_status(public_key:)
+        Personal::RegistrationStatus.new(public_key:, auth:).call
+      end
+
+      def set_webhook(url:)
+        Personal::CorporateWebhook.new(url: url, auth:).call
+      end
+
+      def settings
+        Personal::Settings.new(auth:).call
+      end
+
+      private
+
+      attr_reader :private_key, :key_id
+
+      def auth(request_id: nil)
+        Auth::Corporate.new(private_key:, key_id:, request_id:)
+      end
+    end
+  end
+end

--- a/lib/monobank/methods/base.rb
+++ b/lib/monobank/methods/base.rb
@@ -3,7 +3,7 @@ require 'monobank/resources/error'
 module Monobank
   module Methods
     class Base
-      def initialize(auth:)
+      def initialize(auth: nil)
         @auth = auth
       end
 
@@ -18,13 +18,17 @@ module Monobank
 
       attr_reader :auth
 
+      def pathname
+        raise NotImplementedError
+      end
+
       def response
         raise NotImplementedError
       end
 
       def options
         {
-          headers: auth.to_headers,
+          headers: auth&.to_headers(pathname:),
           body: body.to_json
         }
       end

--- a/lib/monobank/methods/base.rb
+++ b/lib/monobank/methods/base.rb
@@ -3,6 +3,10 @@ require 'monobank/resources/error'
 module Monobank
   module Methods
     class Base
+      def initialize(auth:)
+        @auth = auth
+      end
+
       def call
         attributes = response
         return define_resources(attributes) if attributes.code == 200
@@ -12,7 +16,7 @@ module Monobank
 
       private
 
-      attr_reader :token
+      attr_reader :auth
 
       def response
         raise NotImplementedError
@@ -20,7 +24,7 @@ module Monobank
 
       def options
         {
-          headers: { 'X-Token' => token.to_s },
+          headers: auth.to_headers,
           body: body.to_json
         }
       end

--- a/lib/monobank/methods/base.rb
+++ b/lib/monobank/methods/base.rb
@@ -28,9 +28,13 @@ module Monobank
 
       def options
         {
-          headers: auth&.to_headers(pathname:),
+          headers: (headers || {}).merge(auth&.to_headers(pathname:) || {}),
           body: body.to_json
         }
+      end
+
+      def headers
+        {}
       end
 
       def body; end

--- a/lib/monobank/personal/auth_check.rb
+++ b/lib/monobank/personal/auth_check.rb
@@ -1,0 +1,22 @@
+require 'monobank/methods/get'
+require 'monobank/resources/personal/auth_check'
+
+module Monobank
+  module Personal
+    class AuthCheck < Methods::Get
+      ENDPOINT = '/personal/auth/request'.freeze
+
+      private
+
+      attr_reader :request_id
+
+      def pathname
+        ENDPOINT
+      end
+
+      def define_resources(attributes)
+        Monobank::Resources::Personal::AuthCheck.new(attributes)
+      end
+    end
+  end
+end

--- a/lib/monobank/personal/auth_request.rb
+++ b/lib/monobank/personal/auth_request.rb
@@ -1,0 +1,31 @@
+require 'monobank/methods/post'
+require 'monobank/resources/personal/auth_request'
+
+module Monobank
+  module Personal
+    class AuthRequest < Methods::Post
+      ENDPOINT = '/personal/auth/request'.freeze
+
+      def initialize(callback: nil, **rest)
+        super(**rest)
+        @callback = callback
+      end
+
+      private
+
+      attr_reader :callback
+
+      def pathname
+        ENDPOINT
+      end
+
+      def headers
+        {'X-Callback' => callback} if callback
+      end
+
+      def define_resources(attributes)
+        Monobank::Resources::Personal::AuthRequest.new(attributes)
+      end
+    end
+  end
+end

--- a/lib/monobank/personal/client_info.rb
+++ b/lib/monobank/personal/client_info.rb
@@ -6,10 +6,6 @@ module Monobank
     class ClientInfo < Methods::Get
       ENDPOINT = '/personal/client-info'.freeze
 
-      def initialize(token:)
-        @token = token
-      end
-
       private
 
       def pathname

--- a/lib/monobank/personal/corporate_webhook.rb
+++ b/lib/monobank/personal/corporate_webhook.rb
@@ -1,0 +1,15 @@
+require 'monobank/personal/webhook'
+
+module Monobank
+  module Personal
+    class CorporateWebhook < Webhook
+      ENDPOINT = '/personal/corp/webhook'.freeze
+
+      private
+
+      def pathname
+        ENDPOINT
+      end
+    end
+  end
+end

--- a/lib/monobank/personal/registration.rb
+++ b/lib/monobank/personal/registration.rb
@@ -1,0 +1,46 @@
+require 'monobank/methods/post'
+require 'monobank/resources/personal/registration'
+
+module Monobank
+  module Personal
+    class Registration < Methods::Post
+      ENDPOINT = '/personal/auth/registration'.freeze
+
+      def initialize(public_key:, name:, description:, contact_person:, phone:, email:, logo:, **rest)
+        super(**rest)
+
+        @public_key = public_key
+        @name = name
+        @description = description
+        @contact_person = contact_person
+        @phone = phone
+        @email = email
+        @logo = logo
+      end
+
+      def pathname
+        ENDPOINT
+      end
+
+      private
+
+      attr_reader :public_key, :name, :description, :contact_person, :phone, :email, :logo
+
+      def body
+        {
+          pubkey: public_key,
+          name:,
+          description:,
+          contactPerson: contact_person,
+          phone:,
+          email:,
+          logo:
+        }
+      end
+
+      def define_resources(attributes)
+        Resources::Personal::Registration.new(attributes)
+      end
+    end
+  end
+end

--- a/lib/monobank/personal/registration_status.rb
+++ b/lib/monobank/personal/registration_status.rb
@@ -1,0 +1,32 @@
+require 'monobank/methods/post'
+require 'monobank/resources/personal/registration_status'
+
+module Monobank
+  module Personal
+    class RegistrationStatus < Methods::Post
+      ENDPOINT = '/personal/auth/registration/status'.freeze
+
+      def initialize(public_key:, **rest)
+        super(**rest)
+
+        @public_key = public_key
+      end
+
+      def pathname
+        ENDPOINT
+      end
+
+      private
+
+      attr_reader :public_key
+
+      def body
+        { pubkey: public_key }
+      end
+
+      def define_resources(attributes)
+        Resources::Personal::RegistrationStatus.new(attributes)
+      end
+    end
+  end
+end

--- a/lib/monobank/personal/settings.rb
+++ b/lib/monobank/personal/settings.rb
@@ -1,0 +1,20 @@
+require 'monobank/methods/post'
+require 'monobank/resources/personal/settings'
+
+module Monobank
+  module Personal
+    class Settings < Methods::Post
+      ENDPOINT = '/personal/corp/settings'.freeze
+
+      def pathname
+        ENDPOINT
+      end
+
+      private
+
+      def define_resources(attributes)
+        Resources::Personal::Settings.new(attributes)
+      end
+    end
+  end
+end

--- a/lib/monobank/personal/statement.rb
+++ b/lib/monobank/personal/statement.rb
@@ -6,8 +6,9 @@ module Monobank
     class Statement < Methods::Get
       ENDPOINT = '/personal/statement'.freeze
 
-      def initialize(token:, account_id:, from:, to:)
-        @token = token
+      def initialize(account_id:, from:, to:, **rest)
+        super(**rest)
+
         @account_id = account_id
         @from = from
         @to = to

--- a/lib/monobank/personal/webhook.rb
+++ b/lib/monobank/personal/webhook.rb
@@ -6,8 +6,9 @@ module Monobank
     class Webhook < Methods::Post
       ENDPOINT = '/personal/webhook'.freeze
 
-      def initialize(token:, url:)
-        @token = token
+      def initialize(url:, **rest)
+        super(**rest)
+
         @url = url
       end
 

--- a/lib/monobank/resources/personal/auth_check.rb
+++ b/lib/monobank/resources/personal/auth_check.rb
@@ -1,0 +1,11 @@
+require 'monobank/resources/base'
+
+module Monobank
+  module Resources
+    module Personal
+      class AuthCheck < Base
+        define_fields %w[status]
+      end
+    end
+  end
+end

--- a/lib/monobank/resources/personal/auth_request.rb
+++ b/lib/monobank/resources/personal/auth_request.rb
@@ -1,0 +1,15 @@
+require 'monobank/resources/base'
+
+module Monobank
+  module Resources
+    module Personal
+      class AuthRequest < Base
+        define_fields %w[accept_url]
+
+        def request_id
+          @attributes['token_request_id']
+        end
+      end
+    end
+  end
+end

--- a/lib/monobank/resources/personal/registration.rb
+++ b/lib/monobank/resources/personal/registration.rb
@@ -1,0 +1,11 @@
+require 'monobank/resources/base'
+
+module Monobank
+  module Resources
+    module Personal
+      class Registration < Base
+        define_fields %w[status]
+      end
+    end
+  end
+end

--- a/lib/monobank/resources/personal/registration_status.rb
+++ b/lib/monobank/resources/personal/registration_status.rb
@@ -1,0 +1,11 @@
+require 'monobank/resources/base'
+
+module Monobank
+  module Resources
+    module Personal
+      class RegistrationStatus < Base
+        define_fields %w[key_id status]
+      end
+    end
+  end
+end

--- a/lib/monobank/resources/personal/settings.rb
+++ b/lib/monobank/resources/personal/settings.rb
@@ -1,0 +1,11 @@
+require 'monobank/resources/base'
+
+module Monobank
+  module Resources
+    module Personal
+      class Settings < Base
+        define_fields %w[name permissions webhook]
+      end
+    end
+  end
+end

--- a/monobank.gemspec
+++ b/monobank.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'
   spec.add_development_dependency 'rspec', '~> 3.8', '>= 3.8.0'
+  spec.add_development_dependency 'webmock'
 end

--- a/spec/monobank_corporate_spec.rb
+++ b/spec/monobank_corporate_spec.rb
@@ -126,5 +126,165 @@ describe Monobank::Corporate do
         expect(result.webhook).to eq 'https://example.com/mono/corp/webhook/maybesomegibberishuniquestringbutnotnecessarily'
       end
     end
+
+    context '.auth_request' do
+      let(:headers) { {} }
+
+      before do
+        stub_request(:post, 'https://api.monobank.ua/personal/auth/request').
+          with(
+            headers: {
+              'X-Key-Id' => '28a75537175a018645e6f8b14be7681791e701e0',
+              'X-Sign' => '__BASE64____SIGNED__1706652000/personal/auth/request',
+              'X-Time' => '1706652000',
+              **headers
+            }).
+          to_return(
+            status: 200,
+            body: {
+              "tokenRequestId": "uLkwh3NzFAfEkj7urj5C7AU_",
+              "acceptUrl": "https://mbnk.app/auth/uLkwh3NzFAfEkj7urj5C7AU_"
+            }.to_json,
+            headers: {'Content-Type' => 'application/json'}
+          )
+      end
+
+      it 'returns correct data' do
+        result = Monobank::Corporate.auth_request
+
+        expect(result.request_id).to eq 'uLkwh3NzFAfEkj7urj5C7AU_'
+        expect(result.accept_url).to eq 'https://mbnk.app/auth/uLkwh3NzFAfEkj7urj5C7AU_'
+      end
+
+      context 'when a callback is passed' do
+        let(:headers) { {'X-Callback' => 'https://example.com' }}
+
+        it 'returns passes it as headers' do
+          result = Monobank::Corporate.auth_request(callback: 'https://example.com')
+
+          expect(result.request_id).to eq 'uLkwh3NzFAfEkj7urj5C7AU_'
+          expect(result.accept_url).to eq 'https://mbnk.app/auth/uLkwh3NzFAfEkj7urj5C7AU_'
+        end
+      end
+    end
+
+    context 'with request_id' do
+      let(:request_id) { 'uLkwh3NzFAfEkj7urj5C7AU_' }
+
+      context '.auth_check' do
+        before do
+          stub_request(:get, 'https://api.monobank.ua/personal/auth/request').
+            with(
+              headers: {
+                'X-Key-Id' => '28a75537175a018645e6f8b14be7681791e701e0',
+                'X-Request-Id' => 'uLkwh3NzFAfEkj7urj5C7AU_',
+                'X-Sign' => '__BASE64____SIGNED__1706652000uLkwh3NzFAfEkj7urj5C7AU_/personal/auth/request',
+                'X-Time' => '1706652000'
+              }).
+            to_return(
+              status: 200,
+              body: { status: 'ok' }.to_json,
+              headers: {'Content-Type' => 'application/json'}
+            )
+        end
+
+        it 'returns correct data' do
+          result = Monobank::Corporate.auth_check(request_id:)
+
+          expect(result.status).to eq 'ok'
+        end
+      end
+
+      context '.client_info' do
+        before do
+          stub_request(:get, 'https://api.monobank.ua/personal/client-info').
+            with(
+              headers: {
+                'X-Key-Id' => '28a75537175a018645e6f8b14be7681791e701e0',
+                'X-Request-Id' => 'uLkwh3NzFAfEkj7urj5C7AU_',
+                'X-Sign' => '__BASE64____SIGNED__1706652000uLkwh3NzFAfEkj7urj5C7AU_/personal/client-info',
+                'X-Time' => '1706652000'
+              }).
+            to_return(
+              status: 200,
+              body: {
+                "clientId": "3MSaMMtczs",
+                "name": "Мазепа Іван",
+                "webHookUrl": "https://mysomesite.copm/some_random_data_for_security",
+                "permissions": "psf",
+                "accounts": [
+                  {
+                    "id": "kKGVoZuHWzqVoZuH",
+                    "sendId": "uHWzqVoZuH",
+                    "balance": 10000000,
+                    "creditLimit": 10000000,
+                    "type": "black",
+                    "currencyCode": 980,
+                    "cashbackType": "UAH",
+                    "maskedPan": [
+                      "537541******1234"
+                    ],
+                    "iban": "UA733220010000026201234567890"
+                  }
+                ]
+              }.to_json,
+              headers: {'Content-Type' => 'application/json'}
+            )
+        end
+
+        it 'returns correct data' do
+          result = Monobank::Corporate.client_info(request_id:)
+
+          expect(result.name).to eq 'Мазепа Іван'
+          expect(result.accounts.length).to eq 1
+        end
+      end
+
+      context '.statement' do
+        before do
+          stub_request(:get, 'https://api.monobank.ua/personal/statement/0/1546304461').
+            with(
+              headers: {
+                'X-Key-Id' => '28a75537175a018645e6f8b14be7681791e701e0',
+                'X-Request-Id' => 'uLkwh3NzFAfEkj7urj5C7AU_',
+                'X-Sign' => '__BASE64____SIGNED__1706652000uLkwh3NzFAfEkj7urj5C7AU_/personal/statement/0/1546304461',
+                'X-Time' => '1706652000'
+              }).
+            to_return(
+              status: 200,
+              body: [
+                {
+                  "id": "ZuHWzqkKGVo=",
+                  "time": 1554466347,
+                  "description": "Покупка щастя",
+                  "mcc": 7997,
+                  "originalMcc": 7997,
+                  "hold": false,
+                  "amount": -95000,
+                  "operationAmount": -95000,
+                  "currencyCode": 980,
+                  "commissionRate": 0,
+                  "cashbackAmount": 19000,
+                  "balance": 10050000,
+                  "comment": "За каву",
+                  "receiptId": "XXXX-XXXX-XXXX-XXXX",
+                  "counterEdrpou": "3096889974",
+                  "counterIban": "UA898999980000355639201001404",
+                  "counterName": "ТОВАРИСТВО З ОБМЕЖЕНОЮ ВІДПОВІДАЛЬНІСТЮ «ВОРОНА»"
+                }
+              ].to_json,
+              headers: {'Content-Type' => 'application/json'}
+            )
+        end
+
+        it 'returns correct data' do
+          result = Monobank::Corporate.statement(request_id:, account_id: 0, from: 1546304461)
+
+          expect(result.first.id).to eq 'ZuHWzqkKGVo='
+          expect(result.first.amount).to eq -95000
+          expect(result.first.currency_code).to eq 980
+        end
+      end
+    end
   end
 end

--- a/spec/monobank_corporate_spec.rb
+++ b/spec/monobank_corporate_spec.rb
@@ -1,0 +1,130 @@
+describe Monobank::Corporate do
+  let(:key_id) { nil }
+
+  before do
+    allow(Time).to receive(:now).and_return(Time.parse('2024-01-31'))
+
+    fake_private_key = OpenSSL::PKey::EC.new
+    allow(fake_private_key).to(receive(:sign)) { |_, args| "__SIGNED__#{args}" }
+    allow_any_instance_of(Monobank::Auth::Corporate).to receive(:init_key).and_return(fake_private_key)
+
+    allow(Base64).to(receive(:strict_encode64)) { |arg| "__BASE64__#{arg}" }
+
+    Monobank::Corporate.configure(private_key: 'FAKE PRIVATE KEY', key_id:)
+  end
+
+  context '.registration' do
+    before do
+      stub_request(:post, 'https://api.monobank.ua/personal/auth/registration').
+        with(
+          body: {
+            "pubkey": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZZd0VBWUhLb1pJemow...",
+            "name": "ТОВ \"Ворона\"",
+            "description": "Ми робимо найрозумніший PFM з усіх можливих і нам потрібен доступ до виписка користувача, щоб створювати красиву статистику",
+            "contactPerson": "Роман Шевченко",
+            "phone": "380671234567",
+            "email": "etс@example.com",
+            "logo": "iVBORw0KGgoAAAANSUhEUgAAAUAAAACECAYAAADhnvK8AAAapElEQVR42..."
+          }.to_json,
+          headers: {
+            'X-Sign'=>'__BASE64____SIGNED__1706652000/personal/auth/registration',
+            'X-Time'=>'1706652000'
+          }).
+        to_return(status: 200, body: { status: 'New' }.to_json, headers: {'Content-Type' => 'application/json'})
+    end
+
+    it 'returns correct data' do
+      result = Monobank::Corporate.registration(
+        public_key: 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZZd0VBWUhLb1pJemow...',
+        name: 'ТОВ "Ворона"',
+        description: 'Ми робимо найрозумніший PFM з усіх можливих і нам потрібен доступ до виписка користувача, щоб створювати красиву статистику',
+        contact_person: 'Роман Шевченко',
+        phone: '380671234567',
+        email: 'etс@example.com',
+        logo: 'iVBORw0KGgoAAAANSUhEUgAAAUAAAACECAYAAADhnvK8AAAapElEQVR42...'
+      )
+
+      expect(result.status).to eq 'New'
+    end
+  end
+
+  context '.registration_status' do
+    before do
+      stub_request(:post, 'https://api.monobank.ua/personal/auth/registration/status').
+        with(
+          body: {
+            "pubkey": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZZd0VBWUhLb1pJemow..."
+          }.to_json,
+          headers: {
+            'X-Sign' => '__BASE64____SIGNED__1706652000/personal/auth/registration/status',
+            'X-Time' => '1706652000'
+          }).
+        to_return(
+          status: 200,
+          body: { status: 'Approved', keyId: '28a75537175a018645e6f8b14be7681791e701e0' }.to_json,
+          headers: {'Content-Type' => 'application/json'}
+        )
+    end
+
+    it 'returns correct data' do
+      result = Monobank::Corporate.registration_status(public_key: 'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZZd0VBWUhLb1pJemow...')
+
+      expect(result.status).to eq 'Approved'
+      expect(result.key_id).to eq '28a75537175a018645e6f8b14be7681791e701e0'
+    end
+  end
+
+  context 'with key_id' do
+    let(:key_id) { '28a75537175a018645e6f8b14be7681791e701e0' }
+
+    context '.set_webhook' do
+      before do
+        stub_request(:post, 'https://api.monobank.ua/personal/corp/webhook').
+          with(
+            body: {'webHookUrl': 'https://example.com/some_random_data_for_security'}.to_json,
+            headers: {
+              'X-Key-Id' => '28a75537175a018645e6f8b14be7681791e701e0',
+              'X-Sign' => '__BASE64____SIGNED__1706652000/personal/corp/webhook',
+              'X-Time' => '1706652000'
+            }).
+          to_return(status: 200, body: {'status' => 'ok'}.to_json, headers: {'Content-Type' => 'application/json'})
+      end
+
+      it 'returns correct data' do
+        result = Monobank::Corporate.set_webhook(url: 'https://example.com/some_random_data_for_security')
+
+        expect(result.status).to eq 'ok'
+      end
+    end
+
+    context '.settings' do
+      before do
+        stub_request(:post, 'https://api.monobank.ua/personal/corp/settings').
+          with(
+            headers: {
+              'X-Key-Id' => '28a75537175a018645e6f8b14be7681791e701e0',
+              'X-Sign' => '__BASE64____SIGNED__1706652000/personal/corp/settings',
+              'X-Time' => '1706652000'
+            }).
+          to_return(
+            status: 200,
+            body: {
+              "pubkey": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZZd0VBWUhLb1pJemow...",
+              "name": "Компанія",
+              "permission": "psf",
+              "logo": "iVBORw0KGgoAAAANSUhEUgAAAUAAAACECAYAAADhnvK8AAAapElEQVR42...",
+              "webhook": "https://example.com/mono/corp/webhook/maybesomegibberishuniquestringbutnotnecessarily"
+            }.to_json,
+            headers: {'Content-Type' => 'application/json'}
+          )
+      end
+
+      it 'returns correct data' do
+        result = Monobank::Corporate.settings
+
+        expect(result.name).to eq 'Компанія'
+        expect(result.webhook).to eq 'https://example.com/mono/corp/webhook/maybesomegibberishuniquestringbutnotnecessarily'
+      end
+    end
+  end
+end

--- a/spec/monobank_spec.rb
+++ b/spec/monobank_spec.rb
@@ -4,7 +4,6 @@ describe Monobank do
   context '.bank_currency' do
     before do
       stub_request(:get, "https://api.monobank.ua/bank/currency").
-        with(headers: {'X-Token' => ''}).
         to_return(
           status: 200,
           body: [

--- a/spec/monobank_spec.rb
+++ b/spec/monobank_spec.rb
@@ -1,0 +1,139 @@
+describe Monobank do
+  let(:token) { 'FAKE_TOKEN' }
+
+  context '.bank_currency' do
+    before do
+      stub_request(:get, "https://api.monobank.ua/bank/currency").
+        with(headers: {'X-Token' => ''}).
+        to_return(
+          status: 200,
+          body: [
+            {
+              'currencyCodeA' => 840,
+              'currencyCodeB' => 980,
+              'date' => 1552392228,
+              'rateSell' => 27,
+              'rateBuy' => 27.2,
+              'rateCross' => 27.1
+            }
+          ].to_json,
+          headers: {'Content-Type' => 'application/json'}
+        )
+    end
+
+    it 'returns correct data' do
+      result = Monobank.bank_currency
+      expect(result.first.currency_code_a).to eq 840
+    end
+  end
+
+  context '.client_info' do
+    before do
+      stub_request(:get, "https://api.monobank.ua/personal/client-info").
+        with(headers: {'X-Token' => 'FAKE_TOKEN'}).
+        to_return(
+          status: 200,
+          body: {
+            "clientId": "3MSaMMtczs",
+            "name": "Мазепа Іван",
+            "webHookUrl": "https://example.com/some_random_data_for_security",
+            "permissions": "psfj",
+            "accounts": [
+              {
+                "id": "kKGVoZuHWzqVoZuH",
+                "sendId": "uHWzqVoZuH",
+                "balance": 10000000,
+                "creditLimit": 10000000,
+                "type": "black",
+                "currencyCode": 980,
+                "cashbackType": "UAH",
+                "maskedPan": [
+                  "537541******1234"
+                ],
+                "iban": "UA733220010000026201234567890"
+              }
+            ],
+            "jars": [
+              {
+                "id": "kKGVoZuHWzqVoZuH",
+                "sendId": "uHWzqVoZuH",
+                "title": "На тепловізор",
+                "description": "На тепловізор",
+                "currencyCode": 980,
+                "balance": 1000000,
+                "goal": 10000000
+              }
+            ]
+          }.to_json,
+          headers: {'Content-Type' => 'application/json'}
+        )
+    end
+
+    it 'returns correct data' do
+      result = Monobank.client_info(token:)
+      expect(result.name).to eq 'Мазепа Іван'
+      expect(result.accounts.length).to eq 1
+    end
+  end
+
+  context '.statement' do
+    before do
+      stub_request(:get, "https://api.monobank.ua/personal/statement/0/1546304461").
+        with(headers: {'X-Token' => 'FAKE_TOKEN'}).
+        to_return(
+          status: 200,
+          body: [
+            {
+              "id": "ZuHWzqkKGVo=",
+              "time": 1554466347,
+              "description": "Покупка щастя",
+              "mcc": 7997,
+              "originalMcc": 7997,
+              "hold": false,
+              "amount": -95000,
+              "operationAmount": -95000,
+              "currencyCode": 980,
+              "commissionRate": 0,
+              "cashbackAmount": 19000,
+              "balance": 10050000,
+              "comment": "За каву",
+              "receiptId": "XXXX-XXXX-XXXX-XXXX",
+              "invoiceId": "2103.в.27",
+              "counterEdrpou": "3096889974",
+              "counterIban": "UA898999980000355639201001404",
+              "counterName": "ТОВАРИСТВО З ОБМЕЖЕНОЮ ВІДПОВІДАЛЬНІСТЮ «ВОРОНА»"
+            }
+          ].to_json,
+          headers: {'Content-Type' => 'application/json'}
+        )
+    end
+
+    it 'returns correct data' do
+      result = Monobank.statement(token:, account_id: 0, from: 1546304461)
+      expect(result.first.id).to eq 'ZuHWzqkKGVo='
+      expect(result.first.amount).to eq -95000
+      expect(result.first.currency_code).to eq 980
+    end
+  end
+
+  context '.set_webhook' do
+    before do
+      stub_request(:post, "https://api.monobank.ua/personal/webhook").
+        with(
+          body: {'webHookUrl': 'https://example.com/some_random_data_for_security'}.to_json,
+          headers: {
+            'Accept'=>'*/*',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'User-Agent'=>'Ruby',
+            'X-Token'=>'FAKE_TOKEN'
+          }).
+        to_return(status: 200, body: {'status' => 'ok'}.to_json, headers: {'Content-Type' => 'application/json'})
+    end
+
+    it 'returns correct data' do
+      result = Monobank.set_webhook(token:, url: 'https://example.com/some_random_data_for_security')
+
+      expect(result.status).to eq 'ok'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 
+require 'webmock/rspec'
+
 require 'monobank'
 
 ENGINE_RAILS_ROOT = File.join(File.dirname(__FILE__), '../')


### PR DESCRIPTION
not ready to be reviewed, needs production testing



- new entity type `Auth` (`Monobank::Auth::Private` and `Monobank::Auth::Corporate`): in charge of converting credentials into headers
- new module for the corporate api: Monobank::Corporate
- specs using webmock

discussion points:
- naming: should the regular client be scoped under `Private`?
- is the name `Private` (like `Monobank::Auth::Private`) good at all? "Personal" might be better but confusing because the endpoints start with `/personal` regardless of the api
- is it ok that private api accepts `token` while corporate expects `request_id`? i chose to stick to the terminology from the documentation