### PR TITLE
fix nested snake-casing

### DIFF
--- a/lib/monobank/methods/base.rb
+++ b/lib/monobank/methods/base.rb
@@ -8,10 +8,11 @@ module Monobank
       end
 
       def call
-        attributes = response
-        return define_resources(attributes) if attributes.code == 200
+        http_response = response
+        attributes = http_response.parsed_response
+        return define_resources(attributes) if http_response.code == 200
 
-        Monobank::Resources::Error.new(attributes.merge('code' => attributes.code))
+        Monobank::Resources::Error.new(attributes.merge('code' => http_response.code))
       end
 
       private

--- a/lib/monobank/resources/base.rb
+++ b/lib/monobank/resources/base.rb
@@ -8,27 +8,24 @@ module Monobank
       end
 
       def initialize(attributes)
-        @attributes = {}
-        snake_case_attributes = deep_snake_case(attributes)
-        snake_case_attributes.each { |key, value| @attributes[method_name(key)] = value }
+        @attributes = deep_snake_case(attributes)
       end
 
       def method_name(key)
         key.gsub(/(.)([A-Z])/,'\1_\2').downcase
       end
 
-      def deep_snake_case(hash)
-        return hash unless hash.is_a?(Array) || hash.is_a?(Hash)
-
-        hash.each_with_object({}) do |(key, value), object|
-          object[method_name(key)] =
-            if value.is_a? Hash
-              deep_snake_case(value)
-            elsif value.is_a? Array
-              value.map { |element| deep_snake_case(element) }
-            else
-              value
-            end
+      def deep_snake_case(object)
+        if object.is_a?(Hash)
+          object.map do |key, value|
+            [method_name(key), deep_snake_case(value)]
+          end.to_h
+        elsif object.is_a?(Array)
+          object.map do |value|
+            deep_snake_case(value)
+          end
+        else
+          object
         end
       end
 

--- a/spec/monobank_spec.rb
+++ b/spec/monobank_spec.rb
@@ -72,6 +72,14 @@ describe Monobank do
       result = Monobank.client_info(token:)
       expect(result.name).to eq 'Мазепа Іван'
       expect(result.accounts.length).to eq 1
+      expect(result.accounts.first.currency_code).to eq 980
+      expect(result.attributes).to match hash_including(
+        'accounts' => array_including([
+          hash_including(
+            "currency_code" => 980
+          )
+        ])
+      )
     end
   end
 


### PR DESCRIPTION
currently, deep snake-casing doesn't work

here https://github.com/vergilet/monobank/blob/c72b38785a3d83983be7602f81ee053773fdfde6/lib/monobank/resources/base.rb#L21 the `hash` is always `HTTParty::Response` which short-circuits the method

this leads to differences between, e.g. `client_info.accounts[0].attributes.keys` and `client_info.attributes['accounts'][0].keys`

```rb
client_info = Monobank.client_info(token:)

client_info.accounts[0].attributes.keys
# ^ ["id", "send_id", "balance", "credit_limit", "type", "currency_code", "cashback_type", "masked_pan", "iban"]

client_info.attributes['accounts'][0].keys
# ^ ["id", "sendId", "balance", "creditLimit", "type", "currencyCode", "cashbackType", "maskedPan", "iban"]
```

calling `.parsed_response` on HTTParty::Response ensures that we're always working on arrays/hashes


this will probably be a breaking change tho