### PR TITLE
add type field to Accounts

### DIFF
--- a/lib/monobank/resources/personal/accounts.rb
+++ b/lib/monobank/resources/personal/accounts.rb
@@ -4,7 +4,7 @@ module Monobank
   module Resources
     module Personal
       class Accounts < Base
-        define_fields %w[id balance credit_limit currency_code cashback_type]
+        define_fields %w[id type balance credit_limit currency_code cashback_type]
       end
     end
   end

--- a/spec/monobank_spec.rb
+++ b/spec/monobank_spec.rb
@@ -72,6 +72,7 @@ describe Monobank do
       result = Monobank.client_info(token:)
       expect(result.name).to eq 'Мазепа Іван'
       expect(result.accounts.length).to eq 1
+      expect(result.accounts.first.type).to eq 'black'
       expect(result.accounts.first.currency_code).to eq 980
       expect(result.attributes).to match hash_including(
         'accounts' => array_including([


### PR DESCRIPTION
noticed that the Accounts resource is lacking the `type` field (black/white/fop/etc)