### PR TITLE
bump httparty

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     monobank (1.0.1)
-      httparty (>= 0.21.0, < 0.22.0)
+      httparty (>= 0.21.0, < 0.23.0)
 
 GEM
   remote: https://rubygems.org/

--- a/monobank.gemspec
+++ b/monobank.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{lib}/**/*', 'MIT-LICENSE', 'Rakefile']
   spec.test_files = Dir['spec/**/*']
 
-  spec.add_dependency 'httparty', '>= 0.21.0', '< 0.22.0'
+  spec.add_dependency 'httparty', '>= 0.21.0', '< 0.23.0'
   
   spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.0'
   spec.add_development_dependency 'rspec', '~> 3.8', '>= 3.8.0'


### PR DESCRIPTION
cvs gem should be referenced explicitly, deprecated in ruby 3.3.1, and will be removed in 3.4

ref: https://github.com/jnunemaker/httparty/pull/796

https://github.com/jnunemaker/httparty/releases/tag/v0.22.0 doesn't seem to contain anything major